### PR TITLE
more idiomatic `tracing`

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -81,7 +81,7 @@ impl<Conn: Connection> PoolInner<Conn> {
     // the resolver.
     //
     // Returns the newly added backends, if any.
-    #[instrument(skip(self), target = "qorb::pool::PoolInner::handle_resolve_event")]
+    #[instrument(skip(self), name = "PoolInner::handle_resolve_event")]
     fn handle_resolve_event(
         &mut self,
         event: resolver::Event,
@@ -191,7 +191,7 @@ impl<Conn: Connection> PoolInner<Conn> {
         }
     }
 
-    #[instrument(skip(self), target = "qorb::pool::PoolInner::rebalance")]
+    #[instrument(skip(self), name = "PoolInner::rebalance")]
     async fn rebalance(&mut self) {
         let mut questionable_backend_count = 0;
         let mut usable_backends = vec![];
@@ -320,7 +320,7 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
     /// - resolver: Describes how backends should be found for the service.
     /// - backend_connector: Describes how the connections to a specific
     /// backend should be made.
-    #[instrument(skip(resolver, backend_connector), target = "qorb::pool::Pool::new")]
+    #[instrument(skip(resolver, backend_connector), name = "Pool::new")]
     pub fn new(
         resolver: resolver::BoxedResolver,
         backend_connector: backend::SharedConnector<Conn>,
@@ -337,7 +337,7 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
     }
 
     /// Acquires a handle to a connection within the connection pool.
-    #[instrument(level = "debug", skip(self), err, target = "qorb::pool::Pool::claim")]
+    #[instrument(level = "debug", skip(self), err, name = "Pool::claim")]
     pub async fn claim(&self) -> Result<claim::Handle<Conn>, Error> {
         let (tx, rx) = oneshot::channel();
 

--- a/src/resolvers/dns.rs
+++ b/src/resolvers/dns.rs
@@ -66,14 +66,14 @@ impl Client {
         self.missed_requests_count += 1;
     }
 
-    #[instrument(skip(self), target = "qorb::resolvers::dns::Client::lookup_socket_v6")]
+    #[instrument(skip(self), name = "Client::lookup_socket_v6")]
     async fn lookup_socket_v6(
         &self,
         name: &service::Name,
     ) -> Result<HashMap<backend::Name, BackendRecord>, anyhow::Error> {
         // Look up all the SRV records for this particular name.
         let srv = self.resolver.srv_lookup(&name.0).await?;
-        event!(Level::DEBUG, srv = ?srv, "Successfully looked up SRV record");
+        event!(Level::DEBUG, ?srv, "Successfully looked up SRV record");
 
         let futures = std::iter::repeat(self.resolver.clone())
             .zip(srv.into_iter())
@@ -93,7 +93,7 @@ impl Client {
             .into_iter()
             .flat_map(move |target| match target {
                 Ok((target, aaaa, port)) => {
-                    event!(Level::DEBUG, aaaa = ?aaaa, "Successfully looked up AAAA record");
+                    event!(Level::DEBUG, ?aaaa, "Successfully looked up AAAA record");
                     let expires_at = match self.hardcoded_ttl {
                         Some(duration) => Instant::now().checked_add(duration),
                         None => Some(aaaa.valid_until()),
@@ -218,11 +218,11 @@ impl DnsResolver {
                             first_result.lock().unwrap().get_or_insert(backends);
                         }
                         Ok(Err(err)) => {
-                            event!(Level::ERROR, err = ?err, "DNS request failed");
+                            event!(Level::ERROR, ?err, "DNS request failed");
                             client.mark_error();
                         }
                         Err(err) => {
-                            event!(Level::ERROR, err = ?err, "DNS request timed out");
+                            event!(Level::ERROR, ?err, "DNS request timed out");
                             client.mark_error();
                         }
                     }


### PR DESCRIPTION
This commit makes a couple small style tweaks to the use of `tracing` in
`qorb`. In particular, I've changed the use of span targets that include
the fully-qualified name of the instrumented function to span *names*
that include the type on which the associated function is...associated
with, as the target for an idiomatic `tracing` span or event is
generally module-equivalent, while a span _name_ represents the
particular function.

Additionally, I've changed a few events to use field shorthand syntax so
that we don't have to write the field name out twice, which I think is
just a little bit nicer.