### PR TITLE
reference count `backend::Name`s

### DIFF
--- a/examples/resolver/main.rs
+++ b/examples/resolver/main.rs
@@ -251,7 +251,7 @@ impl Resolver for App {
             events.push(resolver::Event::Added(
                 self.added_backends
                     .iter()
-                    .map(|backend| (backend::Name(backend.address.to_string()), backend.clone()))
+                    .map(|backend| (backend::Name::new(backend.address), backend.clone()))
                     .collect(),
             ));
         }
@@ -264,7 +264,7 @@ impl Resolver for App {
             events.push(resolver::Event::Removed(
                 self.removed_backends
                     .iter()
-                    .map(|backend| backend::Name(backend.address.to_string()))
+                    .map(|backend| backend::Name::new(backend.address))
                     .collect(),
             ));
         }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -16,8 +16,41 @@ pub enum Error {
 
 /// Describes the name of a backend.
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
-pub struct Name(pub String);
+pub struct Name(pub Arc<str>);
+
+impl Name {
+    pub fn new(name: impl ToString) -> Self {
+        Self(name.to_string().into())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Name {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl From<String> for Name {
+    fn from(s: String) -> Self {
+        Self(s.into())
+    }
+}
+
+impl From<&'_ str> for Name {
+    fn from(s: &'_ str) -> Self {
+        Self(s.into())
+    }
+}
+
+impl std::borrow::Borrow<str> for Name {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
 
 /// A single instance of a service.
 #[derive(Clone, PartialEq, Eq, Debug, Hash, Ord, PartialOrd)]

--- a/src/resolvers/dns.rs
+++ b/src/resolvers/dns.rs
@@ -98,10 +98,10 @@ impl Client {
                         Some(duration) => Instant::now().checked_add(duration),
                         None => Some(aaaa.valid_until()),
                     };
-
+                    let name = backend::Name::from(target);
                     Some(aaaa.into_iter().map(move |ip| {
                         (
-                            backend::Name(target.clone()),
+                            name.clone(),
                             BackendRecord {
                                 backend: backend::Backend {
                                     address: SocketAddr::V6(SocketAddrV6::new(*ip, port, 0, 0)),

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -946,7 +946,7 @@ mod test {
         let mut set = Set::new(
             SetConfig::default(),
             5,
-            backend::Name("Test set".to_string()),
+            backend::Name::new("Test set"),
             backend::Backend { address: BACKEND },
             Arc::new(TestConnector::new()),
         );
@@ -971,7 +971,7 @@ mod test {
         let mut set = Set::new(
             SetConfig::default(),
             3,
-            backend::Name("Test set".to_string()),
+            backend::Name::new("Test set"),
             backend::Backend { address: BACKEND },
             Arc::new(TestConnector::new()),
         );
@@ -1014,7 +1014,7 @@ mod test {
         let mut set = Set::new(
             SetConfig::default(),
             0,
-            backend::Name("Test set".to_string()),
+            backend::Name::new("Test set"),
             backend::Backend { address: BACKEND },
             Arc::new(TestConnector::new()),
         );
@@ -1045,7 +1045,7 @@ mod test {
         let mut set = Set::new(
             SetConfig::default(),
             3,
-            backend::Name("Test set".to_string()),
+            backend::Name::from("Test set"),
             backend::Backend { address: BACKEND },
             Arc::new(TestConnector::new()),
         );
@@ -1105,7 +1105,7 @@ mod test {
                 ..Default::default()
             },
             3,
-            backend::Name("Test set".to_string()),
+            backend::Name::new("Test set"),
             backend::Backend { address: BACKEND },
             connector.clone(),
         );


### PR DESCRIPTION
Currently, the `backend::Name` type is represented internally by an
owned `String`. This means that any time a `backend::Name` is cloned,
the `Clone` implementation allocates a new string on the heap and
`memcpy`s the bytes of the the cloned string to the new allocation.
However, `backend::Name`s are never _mutated_ in `qorb`, so cloning them
by performing bytewise copies is unnecessary. Instead, since they are
immutable, we could clone them much more efficiently by reference
counting them, instead.

Therefore, this commit changes the `backend::Name` type from storing a
`String` to storing an `Arc<str>`. They can now be cloned much more
efficiently by just bumping the reference count, and clones of a
`backend::Name` will take up less memory, since there's only one copy of
the actual string. This is probably good, since `backend::Name`s get
cloned kind of a lot, especially when using `qtop` (as they get cloned
two additional times every time service discovery updates are
processed).