### PR TITLE
Add DnsResolverConfig::query_retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "qorb"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "async-bb8-diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = "0.3"
 
 [package]
 name = "qorb"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "Connection Pooling"
 license = "MPL-2.0"


### PR DESCRIPTION
This allows a shorter timeout for re-querying DNS servers when the servers report no records for backends in question.

This came up when running a Nexus test that was sequenced like this:

* Start a DNS server with no records to serve
* Start a qorb pool pointed at that DNS server
* qorb queries the DNS server, sees no records, and goes to sleep for `query_interval`
* A few seconds later, the DNS server is populated with records
* We try to `claim()` a connection from the pool. This times out, because qorb thinks there are no backends (from the initial DNS queries), and we haven't yet hit `query_interval` to check with DNS again

I've confirmed this change fixes that test failure.