### PR TITLE
Add explicit API to terminate pool cleanly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = "0.3"
 
 [package]
 name = "qorb"
-version = "0.0.2"
+version = "0.1.0"
 edition = "2021"
 description = "Connection Pooling"
 license = "MPL-2.0"

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -198,10 +198,6 @@ impl<Conn: Connection> PoolInner<Conn> {
                         // we should respond to them once we've stopped doing
                         // work.
                         Some(Request::Terminate { tx }) => {
-                            // Terminate all background tasks, including:
-                            // - The resolver (may or may not have background
-                            // tasks, this is dependent on the implementation)
-                            // - Each of the slot sets
                             self.terminate().await;
                             let _ignored_result = tx.send(Ok(()));
                             return;
@@ -210,7 +206,10 @@ impl<Conn: Connection> PoolInner<Conn> {
                         //
                         // We stop handling new requests, but have no one to
                         // notify.
-                        None => return,
+                        None => {
+                            self.terminate().await;
+                            return;
+                        }
                     }
                 }
                 // Handle updates from the resolver

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2,6 +2,7 @@
 
 use crate::backend::{self, Backend};
 
+use async_trait::async_trait;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -13,11 +14,17 @@ pub type AllBackends = Arc<BTreeMap<backend::Name, Backend>>;
 /// The resolver is responsible for knowing which [crate::service::Name]
 /// it is resolving. It is responsible for reporting the set of
 /// all possible backends, but not reporting nor tracking their health.
+#[async_trait]
 pub trait Resolver: Send + Sync {
     /// Start running a resolver.
     ///
     /// Returns a receiver to track ongoing activity.
     fn monitor(&mut self) -> watch::Receiver<AllBackends>;
+
+    /// Cleanly terminates the server.
+    ///
+    /// This ensures that background tasks, if they exist, have stopped.
+    async fn terminate(&mut self) {}
 }
 
 /// Helper type for anything that implements the Resolver interface.

--- a/src/resolvers/dns.rs
+++ b/src/resolvers/dns.rs
@@ -442,7 +442,7 @@ impl Resolver for DnsResolver {
         };
 
         let _send_result = terminate_tx.send(());
-        let _join_result = handle.await;
+        handle.await.expect("Resolver task panicked unexpectedly");
     }
 }
 

--- a/src/resolvers/dns.rs
+++ b/src/resolvers/dns.rs
@@ -171,13 +171,16 @@ impl DnsResolverWorker {
             .or_insert_with(|| Client::new(&self.config, address, failure_window));
     }
 
-    async fn run(mut self) {
+    async fn run(mut self, mut terminate_rx: tokio::sync::oneshot::Receiver<()>) {
         let mut query_interval = tokio::time::interval(self.config.query_interval);
         loop {
             let next_tick = query_interval.tick();
             let next_backend_expiration = self.sleep_until_next_backend_expiration();
 
             tokio::select! {
+                _ = &mut terminate_rx => {
+                    return;
+                },
                 _ = next_tick => {
                     self.query_dns().await;
                     if self.backends.is_empty() {
@@ -382,7 +385,8 @@ impl DnsResolverWorker {
 ///
 /// Currently only supports Ipv6 addresses.
 pub struct DnsResolver {
-    handle: tokio::task::JoinHandle<()>,
+    handle: Option<tokio::task::JoinHandle<()>>,
+    terminate_tx: Option<tokio::sync::oneshot::Sender<()>>,
     watch_rx: watch::Receiver<AllBackends>,
 }
 
@@ -401,23 +405,44 @@ impl DnsResolver {
     ) -> Self {
         let (watch_tx, watch_rx) = watch::channel(Arc::new(BTreeMap::new()));
         let worker = DnsResolverWorker::new(watch_tx, service, bootstrap_servers, config);
-        let handle = tokio::task::spawn(async move {
-            worker.run().await;
-        });
+        let (terminate_tx, terminate_rx) = tokio::sync::oneshot::channel();
+        let handle = Some(tokio::task::spawn(async move {
+            worker.run(terminate_rx).await;
+        }));
 
-        Self { handle, watch_rx }
+        Self {
+            handle,
+            terminate_tx: Some(terminate_tx),
+            watch_rx,
+        }
     }
 }
 
 impl Drop for DnsResolver {
     fn drop(&mut self) {
-        self.handle.abort();
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        handle.abort();
     }
 }
 
+#[async_trait::async_trait]
 impl Resolver for DnsResolver {
     fn monitor(&mut self) -> watch::Receiver<AllBackends> {
         self.watch_rx.clone()
+    }
+
+    async fn terminate(&mut self) {
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        let Some(terminate_tx) = self.terminate_tx.take() else {
+            return;
+        };
+
+        let _send_result = terminate_tx.send(());
+        let _join_result = handle.await;
     }
 }
 
@@ -1103,6 +1128,28 @@ mod test {
         tokio::time::timeout(Duration::from_secs(5), wait_for_backends(&mut monitor, 1))
             .await
             .expect("quickly found new entry");
+    }
+
+    #[tokio::test]
+    async fn test_terminate() {
+        setup_tracing_subscriber();
+
+        // Start a DNS server that reports 1 record for the service.
+        let dns_server = DnsServerBuilder::new("example.com", "test.example.com")
+            .add_backend(1234, "test001.example.com.", 1000)
+            .run_updateable()
+            .await;
+
+        let service = service::Name("test.example.com".into());
+        let bootstrap_servers = vec![dns_server.address];
+        let config = DnsResolverConfig {
+            query_interval: Duration::from_secs(60),
+            query_retry_if_no_records_found: Duration::from_millis(100),
+            ..Default::default()
+        };
+        let mut resolver = DnsResolver::new(service, bootstrap_servers, config);
+
+        resolver.terminate().await;
     }
 
     // TODO: Test timeouts?

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -440,6 +440,9 @@ struct SetWorker<Conn: Connection> {
     // Interface for receiving client requests
     rx: mpsc::Receiver<SetRequest<Conn>>,
 
+    // Identifies that the set worker should terminate immediately
+    terminate_rx: tokio::sync::oneshot::Receiver<()>,
+
     // Interface for communicating backend status
     status_tx: watch::Sender<SetState>,
 
@@ -468,6 +471,7 @@ impl<Conn: Connection> SetWorker<Conn> {
     fn new(
         name: backend::Name,
         rx: mpsc::Receiver<SetRequest<Conn>>,
+        terminate_rx: tokio::sync::oneshot::Receiver<()>,
         status_tx: watch::Sender<SetState>,
         config: SetConfig,
         wanted_count: usize,
@@ -486,6 +490,7 @@ impl<Conn: Connection> SetWorker<Conn> {
             stats,
             failure_window,
             rx,
+            terminate_rx,
             status_tx,
             slot_tx,
             slot_rx,
@@ -770,7 +775,7 @@ impl<Conn: Connection> SetWorker<Conn> {
         level = "trace",
         skip(self),
         err,
-        name = ":SetWorker::claim",
+        name = "SetWorker::claim",
         fields(name = ?self.name),
     )]
     async fn claim(&mut self) -> Result<claim::Handle<Conn>, Error> {
@@ -817,6 +822,9 @@ impl<Conn: Connection> SetWorker<Conn> {
     async fn run(&mut self) {
         loop {
             tokio::select! {
+                _ = &mut self.terminate_rx => {
+                    return;
+                },
                 // Recycle old requests
                 request = self.slot_rx.recv() => {
                     match request {
@@ -862,13 +870,15 @@ pub(crate) enum SetState {
 /// A set of slots for a particular backend.
 pub(crate) struct Set<Conn: Connection> {
     tx: mpsc::Sender<SetRequest<Conn>>,
+
     status_rx: watch::Receiver<SetState>,
 
     name: backend::Name,
     pub(crate) stats: Arc<Mutex<Stats>>,
     failure_window: Arc<WindowedCounter>,
 
-    handle: JoinHandle<()>,
+    terminate_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    handle: Option<JoinHandle<()>>,
 }
 
 impl<Conn: Connection> Set<Conn> {
@@ -886,6 +896,7 @@ impl<Conn: Connection> Set<Conn> {
         backend_connector: SharedConnector<Conn>,
     ) -> Self {
         let (tx, rx) = mpsc::channel(1);
+        let (terminate_tx, terminate_rx) = tokio::sync::oneshot::channel();
         let (status_tx, status_rx) = watch::channel(SetState::Offline);
         let failure_duration = config.max_connection_backoff * 2;
         let stats = Arc::new(Mutex::new(Stats::default()));
@@ -898,6 +909,7 @@ impl<Conn: Connection> Set<Conn> {
                 let mut worker = SetWorker::new(
                     name,
                     rx,
+                    terminate_rx,
                     status_tx,
                     config,
                     wanted_count,
@@ -916,7 +928,8 @@ impl<Conn: Connection> Set<Conn> {
             name,
             stats,
             failure_window,
-            handle,
+            terminate_tx: Some(terminate_tx),
+            handle: Some(handle),
         }
     }
 
@@ -1009,11 +1022,27 @@ impl<Conn: Connection> Set<Conn> {
     pub(crate) fn get_stats(&self) -> Stats {
         self.stats.lock().unwrap().clone()
     }
+
+    /// Terminates all connections used by the slot set
+    #[instrument(skip(self), name = "Set::terminate")]
+    pub(crate) async fn terminate(&mut self) {
+        let Some(terminate_tx) = self.terminate_tx.take() else {
+            return;
+        };
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        let _send_result = terminate_tx.send(());
+        let _join_result = handle.await;
+    }
 }
 
 impl<Conn: Connection> Drop for Set<Conn> {
     fn drop(&mut self) {
-        self.handle.abort();
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        handle.abort();
     }
 }
 
@@ -1468,5 +1497,39 @@ mod test {
         // Note that the connection we previously tried to access was marked
         // as failed during validation.
         assert_eq!(raw_conn.get_state(), TestConnectionState::ValidFail);
+    }
+
+    #[tokio::test]
+    async fn test_terminate() {
+        setup_tracing_subscriber();
+        let mut set = Set::new(
+            SetConfig::default(),
+            5,
+            backend::Name::new("Test set"),
+            backend::Backend { address: BACKEND },
+            Arc::new(TestConnector::new()),
+        );
+
+        // Let the connections fill up
+        set.monitor()
+            .wait_for(|state| matches!(state, SetState::Online { .. }))
+            .await
+            .unwrap();
+
+        let conn = set.claim().await.unwrap();
+
+        // We should be able to terminate, even with a claim out.
+        set.terminate().await;
+
+        assert!(matches!(
+            set.claim().await.map(|_| ()).unwrap_err(),
+            Error::SlotWorkerTerminated,
+        ));
+        assert!(matches!(
+            set.set_wanted_count(1).await.unwrap_err(),
+            Error::SlotWorkerTerminated
+        ));
+
+        drop(conn);
     }
 }


### PR DESCRIPTION
Part of https://github.com/oxidecomputer/omicron/issues/6505 

Adds an API to cleanly terminate a qorb Pool, and guarantee that no background tasks are still executing beyond the termination point.