### PR TITLE
Better panic handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "qorb"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-bb8-diesel",

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,0 +1,18 @@
+//! Helpers for joining terminating tasks
+
+use tokio::task::JoinError;
+
+pub(crate) fn propagate_panics(result: Result<(), JoinError>) {
+    match result {
+        // Success or cancellation: Quietly return
+        Ok(()) => return,
+        Err(err) if err.is_cancelled() => return,
+        // Propagate panics
+        Err(err) if err.is_panic() => {
+            std::panic::panic_any(err.into_panic());
+        }
+        Err(err) => {
+            panic!("Unexpected join error (other than panic or cancellation): {err}");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod service;
 // Necessary for implementation
 mod backoff;
 // mod codel;
+mod join;
 mod priority_list;
 mod rebalancer;
 mod slot;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -205,7 +205,8 @@ impl<Conn: Connection> PoolInner<Conn> {
                         // The caller has abandoned their connecion to the pool.
                         //
                         // We stop handling new requests, but have no one to
-                        // notify.
+                        // notify. Given that the caller no longer needs the
+                        // pool, we choose to terminate to avoid leaks.
                         None => {
                             self.terminate().await;
                             return;

--- a/src/resolvers/dns.rs
+++ b/src/resolvers/dns.rs
@@ -442,7 +442,7 @@ impl Resolver for DnsResolver {
         };
 
         let _send_result = terminate_tx.send(());
-        handle.await.expect("Resolver task panicked unexpectedly");
+        crate::join::propagate_panics(handle.await);
     }
 }
 

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -875,7 +875,7 @@ impl<Conn: Connection> SetWorker<Conn> {
                             handle
                         };
 
-                        handle.await.expect("Slot worker panicked");
+                        crate::join::propagate_panics(handle.await);
                     }
                     return;
                 },
@@ -1087,7 +1087,7 @@ impl<Conn: Connection> Set<Conn> {
             return;
         };
         let _send_result = terminate_tx.send(());
-        handle.await.expect("Slot set worker panicked unexpectedly");
+        crate::join::propagate_panics(handle.await);
     }
 }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/oxidecomputer/qorb/pull/45 , with feedback from @hawkw .

Most of this revolves around inspecting `JoinResult` errors, rather than `.expect`-ing them directly.