### PR TITLE
Fix termination bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = "0.3"
 
 [package]
 name = "qorb"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Connection Pooling"
 license = "MPL-2.0"


### PR DESCRIPTION
Fix a `return` not returning enough.

TL:DR: The following code loops forever, because `return` returns from the `async` block, not from `foobar.

```rust
async fn foobar() {
  loop {
     async {
        return;
     }.await;
  }
}
```

This issue impacted slot teardown, and could result in re-using a `oneshot::Receiver`.

This PR fixes that issue, and adds additional tests for termination (which fail without the patch).