### PR TITLE
Use slightly more precise termination semantics when terminating pool

### DIFF
--- a/src/join.rs
+++ b/src/join.rs
@@ -5,8 +5,8 @@ use tokio::task::JoinError;
 pub(crate) fn propagate_panics(result: Result<(), JoinError>) {
     match result {
         // Success or cancellation: Quietly return
-        Ok(()) => return,
-        Err(err) if err.is_cancelled() => return,
+        Ok(()) => (),
+        Err(err) if err.is_cancelled() => (),
         // Propagate panics
         Err(err) if err.is_panic() => {
             std::panic::panic_any(err.into_panic());


### PR DESCRIPTION
Previously, the Pool::terminate command would return when the pool has finished processing work, but before the pool's tokio::task had technically returned.

This commit changes that behavior to actually wait until the tokio::task has been joined successfully.

As far as I know, this should result in the same user-visible behavior, but is slightly less risky from the perspective of "have we actually stopped running things when terminate returns?"