### PR TITLE
Terminate rebalance tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ mod join;
 mod priority_list;
 mod rebalancer;
 mod slot;
+#[cfg(test)]
+mod test_utils;
 mod window_counter;
 
 // Default implementations of generic interfaces

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -42,9 +42,7 @@ enum Request<Conn: Connection> {
     Claim {
         tx: oneshot::Sender<Result<claim::Handle<Conn>, Error>>,
     },
-    Terminate {
-        tx: oneshot::Sender<Result<(), Error>>,
-    },
+    Terminate,
 }
 
 /// A shared reference to backend stats
@@ -197,9 +195,8 @@ impl<Conn: Connection> PoolInner<Conn> {
                         // The caller has explicitly asked us to terminate, and
                         // we should respond to them once we've stopped doing
                         // work.
-                        Some(Request::Terminate { tx }) => {
+                        Some(Request::Terminate) => {
                             self.terminate().await;
-                            let _ignored_result = tx.send(Ok(()));
                             return;
                         },
                         // The caller has abandoned their connecion to the pool.
@@ -404,7 +401,7 @@ impl<Conn: Connection> PoolInner<Conn> {
 
 /// Manages a set of connections to a service
 pub struct Pool<Conn: Connection> {
-    handle: tokio::task::JoinHandle<()>,
+    handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     tx: mpsc::Sender<Request<Conn>>,
     stats: Stats,
     claim_timeout: Duration,
@@ -472,7 +469,7 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
         });
 
         Self {
-            handle,
+            handle: Mutex::new(Some(handle)),
             tx,
             stats: Stats {
                 rx: stats_rx,
@@ -484,13 +481,14 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
 
     /// Terminates the connection pool
     pub async fn terminate(&self) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-
         self.tx
-            .send(Request::Terminate { tx })
+            .send(Request::Terminate)
             .await
             .map_err(|_| Error::Terminated)?;
-        rx.await.map_err(|_| Error::Terminated)?
+        if let Some(handle) = self.handle.lock().unwrap().take() {
+            handle.await.map_err(|_| Error::Terminated)?;
+        }
+        Ok(())
     }
 
     pub fn stats(&self) -> &Stats {
@@ -528,7 +526,9 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
 
 impl<Conn: Connection> Drop for Pool<Conn> {
     fn drop(&mut self) {
-        self.handle.abort()
+        if let Some(handle) = self.handle.lock().unwrap().take() {
+            handle.abort();
+        }
     }
 }
 

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -1,0 +1,72 @@
+//! Utilities to help with testing qorb
+
+use crate::backend::{self, Backend, Connector};
+use async_trait::async_trait;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+/// A test-only connector which can slow down connection access
+/// to mimic high-latency connection issues.
+pub struct SlowConnector {
+    delay_ms: AtomicU64,
+    panic_on_access: AtomicBool,
+}
+
+impl SlowConnector {
+    /// Creates a new connector, which only takes 1ms per operation
+    pub fn new() -> Self {
+        Self {
+            delay_ms: AtomicU64::new(1),
+            panic_on_access: AtomicBool::new(false),
+        }
+    }
+
+    /// Stalls all new operations through the connector, forcing them to
+    /// take an unrealistically long time.
+    pub fn stall(&self) {
+        self.delay_ms.store(9999999, Ordering::SeqCst);
+    }
+
+    /// Mark that any future access through the connector should panic.
+    ///
+    /// Although "stall" prevents connections from getting through the
+    /// Connector APIs, this ensures that new connection operations
+    /// aren't even starting.
+    pub fn panic_on_access(&self) {
+        self.panic_on_access.store(true, Ordering::SeqCst);
+    }
+
+    // Internal shared logic for each of the connetor APIs
+    async fn react_to_connection_operation(&self) {
+        if self.panic_on_access.load(Ordering::SeqCst) {
+            panic!("Should not be making new requests through this connector!");
+        }
+
+        let delay_ms = self.delay_ms.load(Ordering::SeqCst);
+        tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+    }
+}
+
+#[async_trait]
+impl Connector for SlowConnector {
+    type Connection = ();
+
+    async fn connect(&self, _backend: &Backend) -> Result<Self::Connection, backend::Error> {
+        self.react_to_connection_operation().await;
+        Ok(())
+    }
+
+    async fn is_valid(&self, _: &mut Self::Connection) -> Result<(), backend::Error> {
+        self.react_to_connection_operation().await;
+        Ok(())
+    }
+
+    async fn on_acquire(&self, _: &mut Self::Connection) -> Result<(), backend::Error> {
+        self.react_to_connection_operation().await;
+        Ok(())
+    }
+
+    async fn on_recycle(&self, _: &mut Self::Connection) -> Result<(), backend::Error> {
+        self.react_to_connection_operation().await;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Refactors the `SlowConnector` to a helper module, and add tests for termination while the pool is rebalancing