### PR TITLE
Emit better errors from pool when claims fail

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -34,14 +34,8 @@ pub enum Error {
     #[error("Backends exist, and appear online, but all claims are used")]
     AllClaimsUsed,
 
-    #[error(transparent)]
-    Slot(#[from] slot::Error),
-
     #[error("Pool terminated")]
     Terminated,
-
-    #[error("Request timed out")]
-    TimedOut,
 }
 
 enum Request<Conn: Connection> {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -18,7 +18,7 @@ use std::sync::{
 };
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, watch};
-use tokio::time::{interval, Duration};
+use tokio::time::interval;
 use tokio_stream::wrappers::WatchStream;
 use tokio_stream::StreamMap;
 use tracing::{event, instrument, Level};
@@ -27,6 +27,12 @@ use tracing::{event, instrument, Level};
 pub enum Error {
     #[error("No backends found for this service")]
     NoBackends,
+
+    #[error("Backends exist, but none are online")]
+    NoBackendsOnline,
+
+    #[error("Backends exist, and appear online, but all claims are used")]
+    AllClaimsUsed,
 
     #[error(transparent)]
     Slot(#[from] slot::Error),
@@ -64,6 +70,12 @@ impl serde::Serialize for BackendStats {
     }
 }
 
+// A claim request that could not complete immediately
+struct ClaimRequest<Conn: Connection> {
+    tx: oneshot::Sender<Result<claim::Handle<Conn>, Error>>,
+    deadline: tokio::time::Instant,
+}
+
 struct PoolInner<Conn: Connection> {
     backend_connector: backend::SharedConnector<Conn>,
 
@@ -71,7 +83,7 @@ struct PoolInner<Conn: Connection> {
     slots: HashMap<backend::Name, slot::Set<Conn>>,
     priority_list: PriorityList<backend::Name>,
 
-    request_queue: VecDeque<oneshot::Sender<Result<claim::Handle<Conn>, Error>>>,
+    request_queue: VecDeque<ClaimRequest<Conn>>,
     policy: Policy,
 
     // Tracks stats for each backend.
@@ -185,6 +197,13 @@ impl<Conn: Connection> PoolInner<Conn> {
         let mut backend_status_stream = StreamMap::new();
         let mut resolver_stream = WatchStream::new(self.resolver.monitor());
         loop {
+            let request_timeout = if let Some(oldest_request) = self.request_queue.front() {
+                tokio::time::sleep_until(oldest_request.deadline)
+            } else {
+                // TODO: This is a hack
+                tokio::time::sleep(tokio::time::Duration::from_secs(10000))
+            };
+
             tokio::select! {
                 // Handle requests from clients
                 request = self.rx.recv() => {
@@ -210,6 +229,29 @@ impl<Conn: Connection> PoolInner<Conn> {
                         }
                     }
                 }
+                // Timeout old requests from clients
+                _ = request_timeout => {
+                    let Some(request) = self.request_queue.pop_front() else {
+                        continue;
+                    };
+                    // We would have claimed this request if we could have done
+                    // it earlier - this request will fail, but help the client
+                    // identify "why".
+                    let err = match self.slots.len() {
+                        0 => Error::NoBackends,
+                        _ => {
+                            if self.slots.values().any(|set| {
+                                matches!(set.get_state(), slot::SetState::Online { .. })
+                            }) {
+                                Error::AllClaimsUsed
+                            } else {
+                                Error::NoBackendsOnline
+                            }
+                        },
+                    };
+
+                    let _ = request.tx.send(Err(err));
+                },
                 // Handle updates from the resolver
                 Some(all_backends) = resolver_stream.next() => {
                     event!(Level::INFO, "Resolver updated known backends");
@@ -248,22 +290,30 @@ impl<Conn: Connection> PoolInner<Conn> {
         let result = self.claim().await;
         if result.is_ok() {
             let _ = tx.send(result);
-        } else {
-            self.request_queue.push_back(tx);
+            return;
         }
+        // If we fail to claim a request...
+        //
+        // - Keep this request in a queue. A backend may gain slots or come
+        // online later.
+        // - Start the clock on a timeout.
+        self.request_queue.push_back(ClaimRequest {
+            tx,
+            deadline: tokio::time::Instant::now() + self.policy.claim_timeout,
+        });
     }
 
     async fn try_claim_from_queue(&mut self) {
         loop {
-            let Some(tx) = self.request_queue.pop_front() else {
+            let Some(request) = self.request_queue.pop_front() else {
                 return;
             };
 
             let result = self.claim().await;
             if result.is_ok() {
-                let _ = tx.send(result);
+                let _ = request.tx.send(result);
             } else {
-                self.request_queue.push_front(tx);
+                self.request_queue.push_front(request);
                 return;
             }
         }
@@ -404,7 +454,6 @@ pub struct Pool<Conn: Connection> {
     handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
     tx: mpsc::Sender<Request<Conn>>,
     stats: Stats,
-    claim_timeout: Duration,
 }
 
 #[derive(Clone)]
@@ -462,7 +511,6 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
     ) -> Self {
         let (tx, rx) = mpsc::channel(1);
         let (stats_tx, stats_rx) = watch::channel(HashMap::default());
-        let claim_timeout = policy.claim_timeout;
         let handle = tokio::task::spawn(async move {
             let worker = PoolInner::new(resolver, backend_connector, policy, rx, stats_tx);
             worker.run().await;
@@ -475,7 +523,6 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
                 rx: stats_rx,
                 claims: Arc::new(AtomicUsize::new(0)),
             },
-            claim_timeout,
         }
     }
 
@@ -508,19 +555,13 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
         // claims; looping at this point would send us to the back of the queue
         // if there were multiple callers.
 
-        let request_claim = async {
-            self.tx
-                .send(Request::Claim { tx })
-                .await
-                .map_err(|_| Error::Terminated)?;
-            let claim = rx.await.map_err(|_| Error::Terminated)?;
-            self.stats.claims.fetch_add(1, Ordering::Relaxed);
-            claim
-        };
-
-        tokio::time::timeout(self.claim_timeout, request_claim)
+        self.tx
+            .send(Request::Claim { tx })
             .await
-            .map_err(|_| Error::TimedOut)?
+            .map_err(|_| Error::Terminated)?;
+        let claim = rx.await.map_err(|_| Error::Terminated)?;
+        self.stats.claims.fetch_add(1, Ordering::Relaxed);
+        claim
     }
 }
 
@@ -543,6 +584,7 @@ mod test {
     use std::collections::BTreeMap;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::time::Duration;
 
     #[derive(Clone)]
     struct TestResolver {
@@ -743,7 +785,7 @@ mod test {
 
             if handle.backend.address == address1 {
                 eprintln!("Still accessing old address; waiting to shift to new backend...");
-                tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+                tokio::time::sleep(Duration::from_millis(10)).await;
                 continue;
             }
 
@@ -764,7 +806,10 @@ mod test {
                     handles.push(handle);
                 }
                 Err(err) => {
-                    assert!(matches!(err, Error::TimedOut), "Unexpected error: {err:?}");
+                    assert!(
+                        matches!(err, Error::AllClaimsUsed,),
+                        "Unexpected error: {err:?}"
+                    );
                     break;
                 }
             }
@@ -873,5 +918,57 @@ mod test {
             pool.claim().await.map(|_| ()).unwrap_err(),
             Error::Terminated,
         ));
+    }
+
+    #[tokio::test]
+    async fn test_better_errors() {
+        setup_tracing_subscriber();
+
+        let resolver = TestResolver::new();
+        let connector = Arc::new(crate::test_utils::FaultyConnector::new());
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+
+        let pool = Pool::new(
+            Box::new(resolver.clone()),
+            connector.clone(),
+            Policy {
+                max_slots: 1,
+                claim_timeout: Duration::from_millis(5),
+                ..Default::default()
+            },
+        );
+
+        // Failure case: No backends appear in the resolver
+        let claim_err = pool.claim().await.map(|_| ()).unwrap_err();
+        assert!(
+            matches!(claim_err, Error::NoBackends),
+            "Unexpected error: {claim_err}"
+        );
+
+        resolver.replace(BTreeMap::from([(
+            backend::Name::new("aaa"),
+            Backend::new(address),
+        )]));
+
+        let claim = pool.claim().await.expect("Failed to make claim");
+
+        // Failure case: We've hit the claim capacity with a backend
+        // that is online.
+        let claim_err = pool.claim().await.map(|_| ()).unwrap_err();
+        assert!(
+            matches!(claim_err, Error::AllClaimsUsed),
+            "Unexpected error: {claim_err}"
+        );
+        connector.start_failing();
+        drop(claim);
+
+        // Failure casae: Although the backend appears in the resolver,
+        // it's not online. Give a more informative error than "no slots
+        // ready".
+        let claim_err = pool.claim().await.map(|_| ()).unwrap_err();
+        assert!(
+            matches!(claim_err, Error::NoBackendsOnline),
+            "Unexpected error: {claim_err}"
+        );
     }
 }


### PR DESCRIPTION
Claims can fail for a few reasons:

- The resolver has seen no backends
- The resolver has seen a backend, but it's offline
- The resolver has seen a backend, and it's online, but no claims are available

Before this PR, qorb would return a "timed out" error in all of these cases, which doesn't help clients identify "why the request failed".

This PR distinguishes between these error cases. In order to do so, it also moves the "claim timeout" logic from
the client thread into the pool tokio::task. 

Fixes https://github.com/oxidecomputer/qorb/issues/56