### PR TITLE
Add better docs for stats

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod pool;
 pub mod qtop;
 pub mod resolver;
 pub mod service;
+pub mod slot;
 
 // Necessary for implementation
 mod backoff;
@@ -31,7 +32,6 @@ mod backoff;
 mod join;
 mod priority_list;
 mod rebalancer;
-mod slot;
 #[cfg(test)]
 mod test_utils;
 mod window_counter;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -465,9 +465,14 @@ pub struct Pool<Conn: Connection> {
     stats: Stats,
 }
 
+/// Pool-side stats, including statistics for each backend.
 #[derive(Clone)]
 pub struct Stats {
+    /// Per-backend statistics
     pub rx: watch::Receiver<HashMap<backend::Name, BackendStats>>,
+
+    /// The total number of claims made (successfully or unsuccessfully)
+    /// within the pool so far.
     pub claims: Arc<AtomicUsize>,
 }
 
@@ -547,6 +552,7 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
         handle.await.map_err(|_| Error::Terminated)
     }
 
+    /// Returns a reference to pool-wide stats
     pub fn stats(&self) -> &Stats {
         &self.stats
     }


### PR DESCRIPTION
Make per-backend stats show up in `cargo doc`