### PR TITLE
Add USDT probes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
+ "usdt",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "qorb"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-bb8-diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1.38"}
 tokio-stream = { version = "0.1", features = [ "sync" ] }
 tokio-tungstenite = "0.24"
 tracing = "0.1"
+usdt = "0.5.0"
 crossterm = "0.28.1"
 hickory-client = { version = "0.24", default-features = false }
 hickory-server = { version = "0.24", default-features = false }
@@ -60,6 +61,7 @@ tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 tokio-stream = { workspace = true, features = [ "sync" ] }
 tokio-tungstenite = { workspace = true, optional = true }
 tracing = "0.1"
+usdt = { workspace = true, optional = true }
 
 [dev-dependencies]
 camino = { workspace = true }
@@ -80,7 +82,9 @@ name = "pool_benchmark"
 harness = false
 
 [features]
-all = [ "diesel_pg", "qtop" ]
-default = []
+all = [ "diesel_pg", "qtop", "probes" ]
+default = [ "probes" ]
 diesel_pg = ["dep:diesel", "dep:diesel-dtrace", "dep:async-bb8-diesel"]
+serde = [ "dep:serde" ]
 qtop = ["dep:dropshot", "dep:tokio-tungstenite", "serde", "dep:serde_json", "dep:schemars"]
+probes = [ "dep:usdt", "serde" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tracing-subscriber = "0.3"
 
 [package]
 name = "qorb"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "Connection Pooling"
 license = "MPL-2.0"

--- a/benches/pool_benchmark.rs
+++ b/benches/pool_benchmark.rs
@@ -88,7 +88,9 @@ async fn concurrent_claims(count: usize) {
         Backend::new(address),
     )]));
 
-    let pool = Arc::new(Pool::new(resolver, connector, Policy::default()));
+    let pool = Arc::new(
+        Pool::new(resolver, connector, Policy::default()).expect("Failed to register probes"),
+    );
 
     let futs: Vec<_> = (0..count)
         .map(|_| {

--- a/examples/README.adoc
+++ b/examples/README.adoc
@@ -93,9 +93,9 @@ CPU     ID                    FUNCTION:NAME
   4  61311 _ZN4qorb4slot21SetWorker$LT$Conn$GT$29take_connected_unclaimed_slot17hc9ea3b0ce1b991a3E:handle-claimed
 ----
 
-Probe also have arguments. For example, the `handle-claimed` probe also includes
-a unique ID as the first argument, and the address of the backend the handle
-is connected to as the second. You can print the address out like this:
+Probes also have arguments. For example, the `handle-claimed` probe includes a
+unique ID as the first argument, and the address of the backend the handle is
+connected to as the second. You can print the address out like this:
 
 [source,bash]
 ----

--- a/examples/README.adoc
+++ b/examples/README.adoc
@@ -48,3 +48,84 @@ connection pooling with "qtop", a tool for inspecting connection pool state.
 # Run this command while the "tcp_echo_workload" is running.
 cargo run --bin qtop "ws://127.0.0.1:42069/qtop/stats"
 ----
+
+= DTrace probes
+
+`qorb` contains a number of DTrace USDT probes, which provide visibility into
+how connections are managed and claims handed out to clients. If `qorb` is
+compiled with the `probes` feature (which is enabled by default), then you can
+see the probes in action when running the `tcp_echo_workload` example.
+
+After setting up the example as described above, start the binary with the
+`--probes` flag:
+
+[source,bash]
+----
+cargo run --example tcp_echo_workload -- --probes
+----
+
+Now, you can see the available probes with the following, which prints out the
+name of each probe, its location in the binary, and its arguments.
+
+[source,bash]
+----
+dtrace -lvn qorb*:::
+----
+
+NOTE:: Running `dtrace` usually requires elevated permissions, so you will have
+to use `sudo` or similar.
+
+One of the probes we see is called `handle-claimed` -- that fires after `qorb`
+has found a handle for a client, and right before handing it back to the caller
+to use. You can use DTrace to see when any claim is taken from the pool with:
+
+[source,bash]
+----
+dtrace -n 'qorb*:::handle-claimed'
+dtrace: description 'qorb*:::handle-claimed' matched 1 probe
+CPU     ID                    FUNCTION:NAME
+  4  61311 _ZN4qorb4slot21SetWorker$LT$Conn$GT$29take_connected_unclaimed_slot17hc9ea3b0ce1b991a3E:handle-claimed
+  6  61311 _ZN4qorb4slot21SetWorker$LT$Conn$GT$29take_connected_unclaimed_slot17hc9ea3b0ce1b991a3E:handle-claimed
+  4  61311 _ZN4qorb4slot21SetWorker$LT$Conn$GT$29take_connected_unclaimed_slot17hc9ea3b0ce1b991a3E:handle-claimed
+  3  61311 _ZN4qorb4slot21SetWorker$LT$Conn$GT$29take_connected_unclaimed_slot17hc9ea3b0ce1b991a3E:handle-claimed
+  5  61311 _ZN4qorb4slot21SetWorker$LT$Conn$GT$29take_connected_unclaimed_slot17hc9ea3b0ce1b991a3E:handle-claimed
+  5  61311 _ZN4qorb4slot21SetWorker$LT$Conn$GT$29take_connected_unclaimed_slot17hc9ea3b0ce1b991a3E:handle-claimed
+  4  61311 _ZN4qorb4slot21SetWorker$LT$Conn$GT$29take_connected_unclaimed_slot17hc9ea3b0ce1b991a3E:handle-claimed
+----
+
+Probe also have arguments. For example, the `handle-claimed` probe also includes
+a unique ID as the first argument, and the address of the backend the handle
+is connected to as the second. You can print the address out like this:
+
+[source,bash]
+----
+dtrace -qn 'qorb*:::handle-claimed { printf("claimed %s\n", copyinstr(arg1)); }'
+claimed [::1]:6002
+claimed [::1]:6002
+claimed [::1]:6001
+claimed [::1]:6001
+claimed [::1]:6001
+claimed [::1]:6002
+claimed [::1]:6003
+claimed [::1]:6001
+claimed [::1]:6002
+----
+
+Most probes have a "start" and "done" variant, which lets us trace how long
+those operations take. For example, we can track how long each claim is held
+like this:
+
+[source,bash]
+----
+dtrace -qn 'qorb*:::handle-claimed { claims[arg0] = timestamp; addrs[arg0] = copyinstr(arg1); }' -n 'qorb*:::handle-returned/claims[arg0]/ { printf("Held conn to %s for %d ms\n", addrs[arg0], (timestamp - claims[arg0]) / 1000 / 1000); claims[arg0] = 0; addrs[arg0] = 0;}'
+Held conn to [::1]:6001 for 131 ms
+Held conn to [::1]:6002 for 830 ms
+Held conn to [::1]:6001 for 40 ms
+Held conn to [::1]:6002 for 134 ms
+Held conn to [::1]:6002 for 834 ms
+Held conn to [::1]:6001 for 857 ms
+Held conn to [::1]:6003 for 811 ms
+----
+
+See the https://illumos.org/books/dtrace/preface.html#preface[Dynamic Tracing
+Guide] for more details on how to use DTrace to instrument production systems!

--- a/examples/tcp_echo_workload/main.rs
+++ b/examples/tcp_echo_workload/main.rs
@@ -169,7 +169,9 @@ async fn main() -> anyhow::Result<()> {
     };
 
     // Actually make the pool!
-    let pool = Arc::new(Pool::new(resolver, backend_connector, policy));
+    let pool = Arc::new(
+        Pool::new(resolver, backend_connector, policy).expect("USDT probe registration failed"),
+    );
 
     #[cfg(feature = "qtop")]
     tokio::spawn(export_stats_for_qtop(pool.stats().clone()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ mod probes {
 
     /// Fires right before attempting to make a connection, with the address
     /// we're connecting to.
-    fn connect__start(id: &usdt::UniqueId, addr: &std::net::SocketAddr) {}
+    fn connect__start(id: &usdt::UniqueId, addr: &str) {}
 
     /// Fires just after successfully making a connection.
     fn connect__done(id: &usdt::UniqueId) {}
@@ -101,13 +101,13 @@ mod probes {
     /// Fires when qorb creates a new handle, before returning it in a call to
     /// `qorb::Pool::claim()`. This includes an ID for the handle, and the
     /// address of the backend the handle is connected to.
-    fn handle__claimed(id: usize, addr: &std::net::SocketAddr) {}
+    fn handle__claimed(id: usize, addr: &str) {}
 
-    /// Fires when qorb recycles a handle, usually when it is dropped.
-    fn handle__recycled(id: usize) {}
+    /// Fires when a handle is returned to qorb, usually when it is dropped.
+    fn handle__returned(id: usize) {}
 
     /// Fires just before we start a health-check to a backend.
-    fn health__check__start(id: &usdt::UniqueId, addr: &std::net::SocketAddr) {}
+    fn health__check__start(id: &usdt::UniqueId, addr: &str) {}
 
     /// Fires after a successful health-check to a backend.
     fn health__check__done(id: &usdt::UniqueId) {}
@@ -116,7 +116,7 @@ mod probes {
     fn health__check__failed(id: &usdt::UniqueId, reason: &str) {}
 
     /// Fires just before we recycle a connection to a backend.
-    fn recycle__start(id: &usdt::UniqueId, addr: &std::net::SocketAddr) {}
+    fn recycle__start(id: &usdt::UniqueId, addr: &str) {}
 
     /// Fires after successfully recycling a connection to a backend.
     fn recycle__done(id: &usdt::UniqueId) {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,39 @@
 //! * To construct a pool, you must supply a [resolver::Resolver] and
 //!   a [backend::Connector]. These are interfaces which specify "how to find
 //!   backends" and "how to create connections to a backend", respectively.
+//!
+//! # DTrace probes
+//!
+//! qorb contains a number of DTrace USDT probes, which fire as the qorb pool
+//! manages its connections. These probes provide visibility into when qorb
+//! initiates connections; checks health; and vends out claims from a pool. The
+//! full list of probes is:
+//!
+//! - `claim-start`: Fires before attempting to make take a claim from the pool.
+//! - `claim-done`: Fires before returning a successful claim to the client.
+//! - `claim-failed`: Fires on failure to take a claim from the pool.
+//! - `connect-start`: Fires before attempting a connection to a backend.
+//! - `connect-done`: Fires after successfully connecting to a backend.
+//! - `connect-failed`: Fires after failing to connect to a backend.
+//! - `handle-claimed`: Fires after claiming a handle from the pool, before
+//!   returning it to the client.
+//! - `handle-recycled`: Fires when a handle is returned to the pool, after it
+//!   is dropped.
+//! - `health-check-start`: Fires when a health check for a backend starts.
+//! - `health-check-done`: Fires when a health check for a backend completes
+//!   successfully.
+//! - `health-check-failed`: Fires when a health check for a backend fails.
+//! - `recycle-start`: Fires before attempting to recycle a connection.
+//! - `recycle-done`: Fires after successsfully recycling a connection.
+//! - `recycle-failed`: Fires when failing to recycle a connection.
+//!
+//! The existence of the probes is behind the `"probes"` feature, which is
+//! enabled by default. Probes are zero-cost unless they are explicitly enabled,
+//! by tracing the program with the `dtrace(1)` command-line tool.
+//!
+//! Also note that consumers of the `qorb` pool need to call
+//! [`usdt::register_probes`] to register the probes with the OS. `qorb` does
+//! not do so automatically.
 
 // Public API
 pub mod backend;
@@ -39,3 +72,55 @@ mod window_counter;
 // Default implementations of generic interfaces
 pub mod connectors;
 pub mod resolvers;
+
+/// USDT probes for tracing how qorb makes pools and hands out claims.
+#[cfg(feature = "probes")]
+#[usdt::provider(provider = "qorb")]
+mod probes {
+    /// Fires right before attempting to acquire a claim from the pool.
+    fn claim__start(id: &usdt::UniqueId) {}
+
+    /// Fires when a claim is successfully acquired from the pool.
+    fn claim__done(id: &usdt::UniqueId) {}
+
+    /// Fires when we _fail_ to acquire a claim from the pool, with a string
+    /// identifying the reason.
+    fn claim__failed(id: &usdt::UniqueId, reason: &str) {}
+
+    /// Fires right before attempting to make a connection, with the address
+    /// we're connecting to.
+    fn connect__start(id: &usdt::UniqueId, addr: &std::net::SocketAddr) {}
+
+    /// Fires just after successfully making a connection.
+    fn connect__done(id: &usdt::UniqueId) {}
+
+    /// Fires just after failing to make a connectiona, with a string
+    /// identifying the reason.
+    fn connect__failed(id: &usdt::UniqueId, reason: &str) {}
+
+    /// Fires when qorb creates a new handle, before returning it in a call to
+    /// `qorb::Pool::claim()`. This includes an ID for the handle, and the
+    /// address of the backend the handle is connected to.
+    fn handle__claimed(id: usize, addr: &std::net::SocketAddr) {}
+
+    /// Fires when qorb recycles a handle, usually when it is dropped.
+    fn handle__recycled(id: usize) {}
+
+    /// Fires just before we start a health-check to a backend.
+    fn health__check__start(id: &usdt::UniqueId, addr: &std::net::SocketAddr) {}
+
+    /// Fires after a successful health-check to a backend.
+    fn health__check__done(id: &usdt::UniqueId) {}
+
+    /// Fires after a failed health-check to a backend.
+    fn health__check__failed(id: &usdt::UniqueId, reason: &str) {}
+
+    /// Fires just before we recycle a connection to a backend.
+    fn recycle__start(id: &usdt::UniqueId, addr: &std::net::SocketAddr) {}
+
+    /// Fires after successfully recycling a connection to a backend.
+    fn recycle__done(id: &usdt::UniqueId) {}
+
+    /// Fires after failing to recycle a connection to a backend.
+    fn recycle__failed(id: &usdt::UniqueId, reason: &str) {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,19 @@
 //! enabled by default. Probes are zero-cost unless they are explicitly enabled,
 //! by tracing the program with the `dtrace(1)` command-line tool.
 //!
-//! Also note that consumers of the `qorb` pool need to call
-//! [`usdt::register_probes`] to register the probes with the OS. `qorb` does
-//! not do so automatically.
+//! On most systems, the USDT probes must be registered with the DTrace kernel
+//! module. This process is technically fallible, although extremely unlikely to
+//! fail in practice. To account for this, the `pool::Pool::new` constructor is
+//! fallible, returning an `Err` if registration fails. However, it's very
+//! context-dependent what one wants to do with this failure -- some
+//! applications may choose to panic, while others would rather have a pool that
+//! can't be instrumented rather than no pool at all.
+//!
+//! To support both of these cases, the `Result` returned from `pool::Pool::new`
+//! gives access to the pool itself in both the `Ok` or `Err` variant. Some
+//! applications may just `unwrap()` or propagate an error, while others may
+//! choose to extract the pool in either case. (This is similar to the
+//! `std::sync::PoisonError`.)
 
 // Public API
 pub mod backend;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -491,6 +491,33 @@ pub struct Stats {
     pub claims: Arc<AtomicUsize>,
 }
 
+/// A wrapper type indicating that the USDT probes could not be registered.
+///
+/// In this case, no probes will be available in the process. However, similar
+/// to `std::sync::PoisonError`, this contains the pool itself. Applications
+/// which don't care about a probe registration failure may still get access to
+/// the pool
+pub struct RegistrationError<Conn: Connection>(Pool<Conn>);
+
+impl<Conn: Connection> std::fmt::Debug for RegistrationError<Conn> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistrationError").finish_non_exhaustive()
+    }
+}
+
+impl<Conn: Connection> std::fmt::Display for RegistrationError<Conn> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        "USDT probe registration failed".fmt(f)
+    }
+}
+
+impl<Conn: Connection> RegistrationError<Conn> {
+    /// Consume the error and get access to the contained pool.
+    pub fn into_inner(self) -> Pool<Conn> {
+        self.0
+    }
+}
+
 impl<Conn: Connection + Send + 'static> Pool<Conn> {
     /// Creates a new connection pool.
     ///
@@ -523,7 +550,7 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
     ///
     /// // Create the connection pool itself.
     /// let policy = Policy::default();
-    /// let pool = Pool::new(resolver, connector, policy);
+    /// let pool = Pool::new(resolver, connector, policy).unwrap();
     ///
     /// // Grab a connection from the pool.
     /// // Note that it may take a moment for the pool to create connections
@@ -532,12 +559,28 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
     ///
     /// # };
     /// ```
+    ///
+    /// # DTrace probe registration
+    ///
+    /// This constructor returns a `Result`, because it attempts to register the
+    /// USDT probes it exposes, a fallible process. However, that failure is
+    /// extremely unlikely to happen in practice, and so the `Err` variant of
+    /// the returned result allows callers to access the constructed `Pool`
+    /// anyway.
+    ///
+    /// This lets applications decide how to handle that failure. Those which
+    /// want to abort if the USDT probes cannot be registered may propagate or
+    /// unwrap the error. Those which don't want a registration failure to be
+    /// fatal may unwrap the error variant to get the pool in any case.
+    ///
+    /// Note that if the `"probes"` feauture is not enabled, this method is
+    /// infallible.
     #[instrument(skip(resolver, backend_connector), name = "Pool::new")]
     pub fn new(
         resolver: resolver::BoxedResolver,
         backend_connector: backend::SharedConnector<Conn>,
         policy: Policy,
-    ) -> Self {
+    ) -> Result<Self, RegistrationError<Conn>> {
         let (tx, rx) = mpsc::channel(1);
         let (stats_tx, stats_rx) = watch::channel(HashMap::default());
         let handle = tokio::task::spawn(async move {
@@ -545,14 +588,21 @@ impl<Conn: Connection + Send + 'static> Pool<Conn> {
             worker.run().await;
         });
 
-        Self {
+        let self_ = Self {
             handle: Mutex::new(Some(handle)),
             tx,
             stats: Stats {
                 rx: stats_rx,
                 claims: Arc::new(AtomicUsize::new(0)),
             },
+        };
+        #[cfg(feature = "probes")]
+        match usdt::register_probes() {
+            Ok(_) => Ok(self_),
+            Err(_) => Err(RegistrationError(self_)),
         }
+        #[cfg(not(feature = "probes"))]
+        Ok(self_)
     }
 
     /// Terminates the connection pool
@@ -698,7 +748,7 @@ mod test {
             Backend::new(address),
         )]));
 
-        let pool = Pool::new(resolver, connector, Policy::default());
+        let pool = Pool::new(resolver, connector, Policy::default()).unwrap();
         let handle = pool.claim().await.expect("Failed to get claim");
 
         assert_eq!(handle.id, 1);
@@ -713,7 +763,7 @@ mod test {
         let connector = Arc::new(TestConnector::new());
         let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
 
-        let pool = Pool::new(resolver.clone(), connector, Policy::default());
+        let pool = Pool::new(resolver.clone(), connector, Policy::default()).unwrap();
 
         let join_handle = tokio::task::spawn(async move {
             let handle = pool.claim().await.expect("Failed to get claim");
@@ -754,7 +804,8 @@ mod test {
                 },
                 ..Default::default()
             },
-        );
+        )
+        .unwrap();
 
         // Fill all the spares with claims
         let mut handles = vec![];
@@ -808,7 +859,8 @@ mod test {
                 claim_timeout: Duration::from_millis(100),
                 ..Default::default()
             },
-        );
+        )
+        .unwrap();
 
         // We can access that first address
         let handle = pool.claim().await.expect("Failed to get claim");
@@ -875,7 +927,7 @@ mod test {
             Backend::new(address),
         )]));
 
-        let pool = Pool::new(resolver, connector, Policy::default());
+        let pool = Pool::new(resolver, connector, Policy::default()).unwrap();
         let handle = pool.claim().await.expect("Failed to get claim");
 
         assert_eq!(handle.id, 1);
@@ -915,7 +967,7 @@ mod test {
             Backend::new(address),
         )]));
 
-        let pool = Pool::new(resolver, connector.clone(), Policy::default());
+        let pool = Pool::new(resolver, connector.clone(), Policy::default()).unwrap();
         let _handle = pool.claim().await.expect("Failed to get claim");
 
         // Create a large delay, which terminate() should skip.
@@ -949,7 +1001,7 @@ mod test {
         // Create a large delay, which terminate() should skip.
         connector.stall();
 
-        let pool = Pool::new(resolver, connector.clone(), Policy::default());
+        let pool = Pool::new(resolver, connector.clone(), Policy::default()).unwrap();
 
         pool.terminate().await.unwrap();
         connector.panic_on_access();
@@ -983,7 +1035,8 @@ mod test {
                 claim_timeout: Duration::from_millis(5),
                 ..Default::default()
             },
-        );
+        )
+        .unwrap();
 
         // Failure case: No backends appear in the resolver
         let claim_err = pool.claim().await.map(|_| ()).unwrap_err();

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -256,7 +256,7 @@ impl<Conn: Connection> Slot<Conn> {
         #[cfg(feature = "probes")]
         let id = usdt::UniqueId::new();
         #[cfg(feature = "probes")]
-        probes::connect__start!(|| (&id, &backend.address));
+        probes::connect__start!(|| (&id, backend.address.to_string()));
         let res = connector.connect(backend).await;
         #[cfg(feature = "probes")]
         match &res {
@@ -295,7 +295,7 @@ impl<Conn: Connection> Slot<Conn> {
         #[cfg(feature = "probes")]
         let id = usdt::UniqueId::new();
         #[cfg(feature = "probes")]
-        probes::recycle__start!(|| (&id, &backend.address));
+        probes::recycle__start!(|| (&id, backend.address.to_string()));
 
         let result = tokio::time::timeout(timeout, connector.on_recycle(&mut conn)).await;
 
@@ -354,7 +354,7 @@ impl<Conn: Connection> Slot<Conn> {
         #[cfg(feature = "probes")]
         let id = usdt::UniqueId::new();
         #[cfg(feature = "probes")]
-        probes::health__check__start!(|| (&id, &backend.address));
+        probes::health__check__start!(|| (&id, backend.address.to_string()));
 
         // It's important that we don't hold the slot lock across an
         // await point. To avoid this issue, we actually take the
@@ -718,7 +718,9 @@ impl<Conn: Connection> SetWorker<Conn> {
                 let borrowed_conn = BorrowedConnection::new(conn, *id);
 
                 #[cfg(feature = "probes")]
-                crate::probes::handle__claimed!(|| (borrowed_conn.id, &self.backend.address));
+                crate::probes::handle__claimed!(|| {
+                    (borrowed_conn.id, self.backend.address.to_string())
+                });
 
                 // The "drop" method of the claim::Handle will return it to
                 // the slot set, through the permit (which is connected to
@@ -742,7 +744,7 @@ impl<Conn: Connection> SetWorker<Conn> {
     fn recycle_connection(&mut self, borrowed_conn: BorrowedConnection<Conn>) {
         let slot_id = borrowed_conn.id;
         #[cfg(feature = "probes")]
-        crate::probes::handle__recycled!(|| slot_id);
+        crate::probes::handle__returned!(|| slot_id);
         let inner = self
             .slots
             .get_mut(&slot_id)


### PR DESCRIPTION
- Adds probes for the start and end of: taking claims, making connections, doing health checks, and recycling connections.
- Adds probes to track the lifetime of a handle itself, from when it is claimed to when it is recycled back to the pool.
- Closes #65