### PR TITLE
implement fixed resolver

### DIFF
--- a/src/resolvers/fixed.rs
+++ b/src/resolvers/fixed.rs
@@ -10,12 +10,12 @@ use std::sync::Arc;
 
 /// A [`Resolver`] that always returns a fixed set of addresses.
 #[derive(Clone, Debug)]
-pub struct StaticResolver {
+pub struct FixedResolver {
     tx: watch::Sender<AllBackends>,
 }
 
-impl StaticResolver {
-    pub fn new(addrs: impl IntoIterator<Item = SocketAddr>) -> StaticResolver {
+impl FixedResolver {
+    pub fn new(addrs: impl IntoIterator<Item = SocketAddr>) -> FixedResolver {
         let all_backends = Arc::new(
             addrs
                 .into_iter()
@@ -23,11 +23,11 @@ impl StaticResolver {
                 .collect(),
         );
         let (tx, _rx) = watch::channel(all_backends);
-        StaticResolver { tx }
+        FixedResolver { tx }
     }
 }
 
-impl Resolver for StaticResolver {
+impl Resolver for FixedResolver {
     fn monitor(&mut self) -> watch::Receiver<AllBackends> {
         self.tx.subscribe()
     }
@@ -39,13 +39,13 @@ mod tests {
 
     use crate::{backend::Backend, backend::Name, resolver::Resolver as _};
 
-    use super::StaticResolver;
+    use super::FixedResolver;
 
     #[test]
-    fn static_resolver_returns_addresses() {
+    fn fixed_resolver_returns_addresses() {
         let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 4444);
         let addr2 = SocketAddr::new("ff:dd:ee::3".parse().unwrap(), 4445);
-        let mut res = StaticResolver::new([addr1, addr2]);
+        let mut res = FixedResolver::new([addr1, addr2]);
         let rx = res.monitor();
         let backends = rx.borrow();
         println!("{:?}", backends);

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod dns;
 pub mod single_host;
+pub mod r#static;

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -1,5 +1,5 @@
 //! Default implementations of [crate::resolver::Resolver]
 
 pub mod dns;
+pub mod fixed;
 pub mod single_host;
-pub mod r#static;

--- a/src/resolvers/static.rs
+++ b/src/resolvers/static.rs
@@ -1,0 +1,58 @@
+//! Implementation of [Resolver] that always returns a fixed set of addresses.
+
+use tokio::sync::watch;
+
+use crate::backend;
+use crate::resolver::{AllBackends, Resolver};
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+/// A [`Resolver`] that always returns a fixed set of addresses.
+#[derive(Clone, Debug)]
+pub struct StaticResolver {
+    tx: watch::Sender<AllBackends>,
+}
+
+impl StaticResolver {
+    pub fn new(addrs: impl IntoIterator<Item = SocketAddr>) -> StaticResolver {
+        let all_backends = Arc::new(
+            addrs
+                .into_iter()
+                .map(|address| (backend::Name::new(address), backend::Backend { address }))
+                .collect(),
+        );
+        let (tx, _rx) = watch::channel(all_backends);
+        StaticResolver { tx }
+    }
+}
+
+impl Resolver for StaticResolver {
+    fn monitor(&mut self) -> watch::Receiver<AllBackends> {
+        self.tx.subscribe()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use crate::{backend::Backend, backend::Name, resolver::Resolver as _};
+
+    use super::StaticResolver;
+
+    #[test]
+    fn static_resolver_returns_addresses() {
+        let addr1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 4444);
+        let addr2 = SocketAddr::new("ff:dd:ee::3".parse().unwrap(), 4445);
+        let mut res = StaticResolver::new([addr1, addr2]);
+        let rx = res.monitor();
+        let backends = rx.borrow();
+        println!("{:?}", backends);
+        assert_eq!(backends.len(), 2);
+        let Backend { address } = backends.get(&Name::new("127.0.0.1:4444")).unwrap();
+        assert_eq!(*address, addr1);
+        let Backend { address } = backends.get(&Name::new("[ff:dd:ee::3]:4445")).unwrap();
+        assert_eq!(*address, addr2);
+    }
+}


### PR DESCRIPTION
I'm wanting this for cases where:

- I have something that needs to talk to a dependency that's usually found in DNS.
- I have CLI programs using that thing where a user might specify a specific backend to use.

The pattern I'm using is to have the thing accept a `watch::Receiver<AllBackends>` and I can give it either the usual resolver or this new `FixedResolver` based on whether it should come from DNS or something the user specified.

I think this could be useful for fixing oxidecomputer/omicron#7941, for example.

This could probably replace `SingleHostResolver` altogether but I didn't want to break consumers.  I also couldn't think of a good way to implement that one in terms of this one that wasn't just as much code.